### PR TITLE
fix note displaying

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -544,7 +544,7 @@ void ConsolePlayer::refreshRegDump()
 
                     consoleColour (yellow, true);
                     ;
-                    cerr << " " << getNote(registers[0x00 + i * 0x07] | ((registers[0x01 + i * 0x07] & 0x0f) << 8))
+                    cerr << " " << getNote(registers[0x00 + i * 0x07] | (registers[0x01 + i * 0x07] << 8))
                          << " $" << setw(3) << setfill('0') << (registers[0x02 + i * 0x07] | ((registers[0x03 + i * 0x07] & 0x0f) << 8));
 
                     // gate changed ?


### PR DESCRIPTION
on line 547 of menu.cpp, ANDing `registers[0x01 + i * 0x07]` with $F caused some notes to be displayed incorrectly, some of them were off by a few semitones, while others by even some octaves

masking that register wasn't making much sense to me, so i got curious and removed that just to see what would happen