### PR TITLE
fix a few typos

### DIFF
--- a/doc/en/sidplayfp.ini.pod
+++ b/doc/en/sidplayfp.ini.pod
@@ -181,14 +181,14 @@ Set the SID emulation engine. Default is RESIDFP.
 
 =item B<C64Model>=I<< <PAL|NTSC|OLD_NTSC|DREAN> >>
 
-Default c64 model to use if not specified by tune, PAL for
+Default C64 model to use if not specified by tune, PAL for
 european PAL-B model, NTSC for american/japanese NTSC-M models,
 OLD_NTSC for NTSC-M models with old video chip and DREAN
 for argentinian PAL-N model. Default is PAL.
 
 =item B<ForceC64Model>=I<true|false>
 
-Force the configured c64 model even if the tune specifies one.
+Force the configured C64 model even if the tune specifies one.
 
 =item B<CiaModel>=I<< <MOS6526|MOS8521> >>
 
@@ -241,12 +241,12 @@ emulation.  The default value is AVERAGE.
 
 =item B<PowerOnDelay>=I<< <number> >>
 
-The c64 power on delay as number of cpu cycles.
+The C64 power on delay in number of CPU cycles.
 If greater than 8191 the delay will be random.
 
 =item B<Sampling>=I<< <INTERPOLATE|RESAMPLE> >>
 
-Set resampling mode.  'Interpolation (less expensive) or
+Set resampling mode:  Interpolation (less expensive) or
 resampling (accurate).
 
 =item B<FastSampling>=I<< <true|false> >>

--- a/doc/en/sidplayfp.ini.pod
+++ b/doc/en/sidplayfp.ini.pod
@@ -55,7 +55,7 @@ Default recording time when writing wave files if Songlength Database is not fou
 
 =item B<Kernal Rom>=I<< <path> >>
 
-Full path for the Kernal Rom file. This is the most important rom and should always be provided, although many tunes will still work without.
+Full path for the Kernal Rom file. This is the most important ROM and should always be provided, although many tunes will still work without.
 By default the program will look for a file named F<kernal> under the following locations:
 
 =over

--- a/doc/en/sidplayfp.pod
+++ b/doc/en/sidplayfp.pod
@@ -17,8 +17,8 @@ B<Sidplayfp> is a music player that emulates various components from a
 Commodore 64 (C64) computer.  The result is a program which can load
 and execute C64 machine code programs which produce music and sound.
 Sidplayfp has been designed for accuracy which results in a quite high
-cpu usage.  Additional playback modes have however been provided to
-allow playback on low specification machines at the cost of accuracy.
+CPU usage.  Additional playback modes have, however, been provided to
+allow playback on low-spec machines at the cost of said accuracy.
 
 
 =head1 OPTIONS
@@ -175,12 +175,12 @@ Use exSID device.
 
 =item B<--cpu-debug>
 
-Display cpu register and assembly dumps, available only
+Display CPU register and assembly dumps, available only
 for debug builds.
 
 =item B<--delay=>I<< [num] >>
 
-Simulate c64 power on delay as number of cpu cycles.
+Simulate C64 power on delay as number of CPU cycles.
 If greater than 8191 the delay will be random.
 This is the default.
 
@@ -280,15 +280,15 @@ The configuration file. See L<sidplayfp.ini(5)> for further details.
 
 =item F<kernal>
 
-The c64 kernal rom dump file.
+The C64 kernal rom dump file.
 
 =item F<basic>
 
-The c64 basic rom dump file.
+The C64 basic rom dump file.
 
 =item F<chargen>
 
-The c64 character generator rom dump file.
+The C64 character generator rom dump file.
 
 =back
 

--- a/doc/en/sidplayfp.pod
+++ b/doc/en/sidplayfp.pod
@@ -280,15 +280,15 @@ The configuration file. See L<sidplayfp.ini(5)> for further details.
 
 =item F<kernal>
 
-The C64 kernal rom dump file.
+The C64 Kernal ROM dump file.
 
 =item F<basic>
 
-The C64 basic rom dump file.
+The C64 BASIC ROM dump file.
 
 =item F<chargen>
 
-The C64 character generator rom dump file.
+The C64 Character Generator ROM dump file.
 
 =back
 

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -68,10 +68,10 @@ static char keytable[] =
     ESC,'[','D',0,          A_LEFT_ARROW,
     ESC,'[','A',0,          A_UP_ARROW,
     ESC,'[','B',0,          A_DOWN_ARROW,
-    // Hmm, in consile there:
+    // Hmm, in console there is:
     ESC,'[','1','~',0,      A_HOME,
     ESC,'[','4','~',0,      A_END,
-    // But in X there:
+    // But in X it's:
     ESC,'[','H',0,          A_HOME,
     ESC,'[','F',0,          A_END,
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -485,7 +485,7 @@ void ConsolePlayer::menu ()
         for (int i=0; i < tuneInfo->sidChips() * 3; i++)
 #endif
         {
-            consoleTable (table_t::middle); cerr << endl; // reserve space for the Voice 3 status
+            consoleTable (table_t::middle); cerr << endl; // reserve space for each voice's status
         }
     }
 #endif

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -115,9 +115,9 @@ uint16_t freqTableNtsc[]
 };
 #endif
 
-// This tables contains chip-profiles which allow us to adjust
+// This tables contains chip profiles which allow us to adjust
 // certain settings that varied wildly between 6581 chips, even
-// made in the same factory on the same day.
+// those made in the same factory on the same day.
 //
 // This works under the assumption that the authors used the
 // same SID chip their entire career.


### PR DESCRIPTION
keyboard.cpp: "consile" -> "console" + add missing "is"
docs: recapitalize a few words, change "low specification" to "low-spec" (both are correct, the latter just sounds more natural)
player.cpp: add missing "those" in comment