### PR TITLE
Adjust song length when forcing C64 model

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -946,26 +946,26 @@ bool ConsolePlayer::open (void)
     // so try the songlength database or keep the default
     if (!m_timer.valid)
     {
-        const int_least32_t length = songlengthDB == sldb_t::MD5
+        int_least32_t length = songlengthDB == sldb_t::MD5
             ? m_database.lengthMs(m_tune)
             : (m_database.length(m_tune) * 1000);
         if (length > 0)
         {
-            m_timer.length = length;
             if (m_engCfg.forceC64Model)
             {
-                // The model is forced. Adjust the songlength
-                // if it doesn't match what the tune is made for.
-                m_timer.length *=
+                // The model is forced. Adjust the song length
+                // if it doesn't match what the tune is made for
+                length *=
                     (tuneInfo->clockSpeed() != SidTuneInfo::CLOCK_PAL)
                     ? FREQ_NTSC
                     : FREQ_PAL;
-                m_timer.length /=
+                length /= 
                     (m_engCfg.defaultC64Model == SidConfig::NTSC) ||
                     (m_engCfg.defaultC64Model == SidConfig::OLD_NTSC)
                     ? FREQ_NTSC
                     : FREQ_PAL;
             }
+            m_timer.length = length;
         }
     }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -948,7 +948,18 @@ bool ConsolePlayer::open (void)
             ? m_database.lengthMs(m_tune)
             : (m_database.length(m_tune) * 1000);
         if (length > 0)
+        {
             m_timer.length = length;
+            if (m_engCfg.forceC64Model)
+            {
+                // The model is forced. Adjust the songlength
+                // if it doesn't match what the tune is made for.
+                m_timer.length *= tuneInfo->clockSpeed() != SidTuneInfo::CLOCK_PAL
+                    ? SidTuneInfo::SPEED_CIA_1A : 50;
+                m_timer.length /= m_engCfg.defaultC64Model == SidConfig::NTSC
+                    ? SidTuneInfo::SPEED_CIA_1A : 50;
+            }
+        }
     }
 
     // Set up the play timer

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -954,9 +954,12 @@ bool ConsolePlayer::open (void)
             {
                 // The model is forced. Adjust the songlength
                 // if it doesn't match what the tune is made for.
-                m_timer.length *= tuneInfo->clockSpeed() != SidTuneInfo::CLOCK_PAL
+                m_timer.length *= 
+                    (tuneInfo->clockSpeed() != SidTuneInfo::CLOCK_PAL)
                     ? SidTuneInfo::SPEED_CIA_1A : 50;
-                m_timer.length /= m_engCfg.defaultC64Model == SidConfig::NTSC
+                m_timer.length /= 
+                    (m_engCfg.defaultC64Model == SidConfig::NTSC) ||
+                    (m_engCfg.defaultC64Model == SidConfig::OLD_NTSC)
                     ? SidTuneInfo::SPEED_CIA_1A : 50;
             }
         }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -63,6 +63,8 @@ using filter_map_iter_t = std::unordered_map<std::string, double>::const_iterato
 
 // Previous song select timeout (4 secs)
 constexpr uint_least32_t SID2_PREV_SONG_TIMEOUT = 4000;
+constexpr uint_least32_t FREQ_PAL = 50;
+constexpr uint_least32_t FREQ_NTSC = 60;
 
 
 const char* ERR_NOT_ENOUGH_MEMORY = "ERROR: Not enough memory.";
@@ -954,13 +956,15 @@ bool ConsolePlayer::open (void)
             {
                 // The model is forced. Adjust the songlength
                 // if it doesn't match what the tune is made for.
-                m_timer.length *= 
+                m_timer.length *=
                     (tuneInfo->clockSpeed() != SidTuneInfo::CLOCK_PAL)
-                    ? SidTuneInfo::SPEED_CIA_1A : 50;
-                m_timer.length /= 
+                    ? FREQ_NTSC
+                    : FREQ_PAL;
+                m_timer.length /=
                     (m_engCfg.defaultC64Model == SidConfig::NTSC) ||
                     (m_engCfg.defaultC64Model == SidConfig::OLD_NTSC)
-                    ? SidTuneInfo::SPEED_CIA_1A : 50;
+                    ? FREQ_NTSC
+                    : FREQ_PAL;
             }
         }
     }


### PR DESCRIPTION
Adjust the song length if we're forcing a model (PAL/NTSC) that doesn't match the tune info. This ensures the song ends at the correct spot.