### PR TITLE
Init driver output before parsing config (#89)

### DIFF
--- a/src/args.cpp
+++ b/src/args.cpp
@@ -168,7 +168,6 @@ int ConsolePlayer::args(int argc, const char *argv[])
     }
 
     // default arg options
-    m_driver.output = output_t::SOUNDCARD;
     m_driver.file   = false;
     m_driver.info   = false;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -402,6 +402,9 @@ ConsolePlayer::ConsolePlayer (const char * const name) :
         if (emulation.powerOnDelay >= 0)
             m_engCfg.powerOnDelay    = emulation.powerOnDelay;
 
+        // Set default output
+        m_driver.output = output_t::SOUNDCARD;
+
         if (!emulation.engine.empty())
         {
             if (emulation.engine.compare(TEXT("RESIDFP")) == 0)


### PR DESCRIPTION
so it doesn't override ini file selection