### PR TITLE
Correctly restore ANSI console (#100)

### DIFF
--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -522,6 +522,9 @@ void ConsolePlayer::menu ()
     // is not disturbed.
     if ( !m_quietLevel )
         cerr << "00:00";
+
+    consoleRestore();
+
     cerr << flush;
 }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1081,18 +1081,6 @@ void ConsolePlayer::close ()
     createSidEmu    (EMU_NONE, nullptr);
     m_engine.load   (nullptr);
     m_engine.config (m_engCfg);
-
-    if (m_quietLevel < 2)
-    {   // Correctly leave ansi mode and get prompt to
-        // end up in a suitable location
-        if ((m_iniCfg.console ()).ansi) {
-            cerr << '\x1b' << "[?25h";
-            cerr << '\x1b' << "[0m";
-        }
-#ifndef _WIN32
-        cerr << endl;
-#endif
-    }
 }
 
 // Flush any hardware sid fifos so all music is played


### PR DESCRIPTION
avoid sending useless ANSI sequences to terminal