### PR TITLE
player.cpp: fix error message when no suitable engine found

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -67,6 +67,7 @@ constexpr uint_least32_t FREQ_NTSC = 60;
 
 
 const char* ERR_NOT_ENOUGH_MEMORY = "ERROR: Not enough memory.";
+const char* ERR_NO_SID_EMULATION  = "ERROR: Requested SID emulation not built in.";
 
 
 #ifdef HAVE_SIDPLAYFP_BUILDERS_RESIDFP_H
@@ -854,8 +855,8 @@ bool ConsolePlayer::createSidEmu(SIDEMUS emu, const SidTuneInfo *tuneInfo)
     if (!m_engCfg.sidEmulation)
     {
         if (emu > EMU_DEFAULT)
-        {   // No sid emulation?
-            displayError (ERR_NOT_ENOUGH_MEMORY);
+        {   // The requested SID emulation was not compiled in.
+            displayError (ERR_NO_SID_EMULATION);
             return false;
         }
     }


### PR DESCRIPTION
When no suitable engine has been built in (eg. when libresid missing) the error message wrongly stating a memory allocation error.